### PR TITLE
Adding support to override the X-esl-outbound header for NAT situations

### DIFF
--- a/lib/conference.js
+++ b/lib/conference.js
@@ -253,7 +253,7 @@ class Conference extends Emitter {
       this.endpoint.api('conference ', `${this.name} recording start ${file}`, (err, evt) => {
         if (err) return callback(err, evt);
         const body = evt.getBody() ;
-        const regexp = new RegExp(`Record file ${file}\n$`);
+        const regexp = new RegExp(`+OK Record file ${file}\n$`);
         if (regexp.test(body)) {
           return callback(null, body);
         }

--- a/lib/conference.js
+++ b/lib/conference.js
@@ -253,7 +253,7 @@ class Conference extends Emitter {
       this.endpoint.api('conference ', `${this.name} recording start ${file}`, (err, evt) => {
         if (err) return callback(err, evt);
         const body = evt.getBody() ;
-        const regexp = new RegExp(`+OK Record file ${file}\n$`);
+        const regexp = new RegExp(`Record file ${file}`);
         if (regexp.test(body)) {
           return callback(null, body);
         }

--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -34,7 +34,7 @@ function requiresDtlsHandshake(sdp) {
  */
 
 class MediaServer extends Emitter {
-  constructor(conn, mrf, listenAddress, listenPort, profile) {
+  constructor(conn, mrf, listenAddress, listenPort, profile, eslOutboundHeader) {
     super() ;
 
     this._conn = conn ;
@@ -74,6 +74,10 @@ class MediaServer extends Emitter {
       }
     } ;
 
+    this.eslOutboundHeader = eslOutboundHeader;
+    if(!this.eslOutboundHeader) {
+      this.eslOutboundHeader = `${listenAddress}:${listenPort}`;
+    }
     this._address = this._conn.socket.remoteAddress;
     this._conn.subscribe(['HEARTBEAT']) ;
     this._conn.on('esl::event::HEARTBEAT::*', this._onHeartbeat.bind(this)) ;
@@ -285,7 +289,7 @@ class MediaServer extends Emitter {
       this.srf.createUAC(uri, {
         headers: Object.assign(opts.headers, {
           'User-Agent': `drachtio-fsmrf:${uuid}`,
-          'X-esl-outbound': `${this.listenAddress}:${this.listenPort}`
+          'X-esl-outbound': `${this.eslOutboundHeader}`
         }),
         localSdp: opts.remoteSdp
       })
@@ -389,7 +393,7 @@ class MediaServer extends Emitter {
         this.srf.createUAC(uri, {
           headers: {
             'User-Agent': `drachtio-fsmrf:${uuid}`,
-            'X-esl-outbound': `${this.listenAddress}:${this.listenPort}`
+            'X-esl-outbound': `${this.eslOutboundHeader}`
           },
           localSdp: req.body
         }, {}, (err, dlg) => {

--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -74,10 +74,7 @@ class MediaServer extends Emitter {
       }
     } ;
 
-    this.eslOutboundHeader = eslOutboundHeader;
-    if(!this.eslOutboundHeader) {
-      this.eslOutboundHeader = `${listenAddress}:${listenPort}`;
-    }
+    this.eslOutboundHeader = eslOutboundHeader;    
     this._address = this._conn.socket.remoteAddress;
     this._conn.subscribe(['HEARTBEAT']) ;
     this._conn.on('esl::event::HEARTBEAT::*', this._onHeartbeat.bind(this)) ;
@@ -97,6 +94,9 @@ class MediaServer extends Emitter {
     server.listen(listenPort, listenAddress, () => {
       this.listenAddress = server.address().address;
       this.listenPort = server.address().port ;
+      if(!this.eslOutboundHeader) {
+        this.eslOutboundHeader = `${this.listenAddress}:${this.listenPort}`;
+      }
       this._server = new esl.Server({server: server, myevents:false}, () => {
         this.emit('connect') ;
 

--- a/lib/mrf.js
+++ b/lib/mrf.js
@@ -56,6 +56,7 @@ class Mrf extends Emitter {
     const secret = opts.secret || 'ClueCon' ;
     const listenPort = opts.listenPort || 0 ; // 0 means any available port
     const listenAddress = opts.listenAddress || this.localAddresses[0] || '0.0.0.0' ;
+    const eslOutboundHeader = opts.eslOutboundHeader || null;
     const profile = opts.profile || 'drachtio_mrf';
 
     function _onError(callback, err) {
@@ -71,7 +72,7 @@ class Mrf extends Emitter {
         debug('initial connection made');
         conn.removeListener('error', listener) ;
 
-        const ms = new MediaServer(conn, this, listenAddress, listenPort, profile) ;
+        const ms = new MediaServer(conn, this, listenAddress, listenPort, profile, eslOutboundHeader) ;
 
         ms.once('ready', () => {
           debug('Mrf#connect - media server is ready for action!');


### PR DESCRIPTION
This PR adds a config parameter on the `connect` function to allow the X-esl-outbound header to be overwritten with a custom value. This solves the related issue I created: https://github.com/davehorton/drachtio-fsmrf/issues/43

*Example:*
```
mrf.connect({address: '123.131.19.169', port: 8021, secret: 'ClueCon', 'listenPort': 8099, 'eslOutboundHeader': '123.55.5.163:8099'})
```