### PR TITLE
startRecord erroring when starting conference

### DIFF
--- a/lib/conference.js
+++ b/lib/conference.js
@@ -253,7 +253,7 @@ class Conference extends Emitter {
       this.endpoint.api('conference ', `${this.name} recording start ${file}`, (err, evt) => {
         if (err) return callback(err, evt);
         const body = evt.getBody() ;
-        const regexp = new RegExp(`Record file ${file}\n$`);
+        const regexp = new RegExp(`+OK Record file ${file}\n$`);
         if (regexp.test(body)) {
           return callback(null, body);
         }


### PR DESCRIPTION
Howdy Dave!

I've found that using conference.startRecording crashes due to this regex not properly handling the result. When I run it, I get a result like this:
```
Error: +OK Record file rtmp://XXX.YYY/ZZZ/05f7cda210ff4ea49122aea69ae595b3 canvas 1
```

Notice the `+OK`. That seems to trip up your regex which causes the crash.