### PR TITLE
Fixing startRecording success Regex

### DIFF
--- a/lib/conference.js
+++ b/lib/conference.js
@@ -253,7 +253,7 @@ class Conference extends Emitter {
       this.endpoint.api('conference ', `${this.name} recording start ${file}`, (err, evt) => {
         if (err) return callback(err, evt);
         const body = evt.getBody() ;
-        const regexp = new RegExp(`Record file ${file}\n$`);
+        const regexp = new RegExp(`Record file ${file}`);
         if (regexp.test(body)) {
           return callback(null, body);
         }


### PR DESCRIPTION
This will work when FreeSWITCH video is enabled.