### PR TITLE
Adding method to modify MRF SDP before its sent back to client

### DIFF
--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -363,6 +363,10 @@ class MediaServer extends Emitter {
           remoteSdp: opts.remoteSdp || req.body,
           codecs: opts.codecs
         });
+        if(opts.modifyMrfSdpResponse instanceof Function) {
+          debug(`MediaServer#connectCaller - modifying (normal scenario) sdp returned using opts.modifyMrfSdpResponse on ${uuid}`) ;
+          endpoint.local.sdp = opts.modifyMrfSdpResponse(endpoint.local.sdp)
+        }
         const dialog = await this.srf.createUAS(req, res, {
           localSdp: endpoint.local.sdp,
           headers: opts.headers
@@ -395,7 +399,10 @@ class MediaServer extends Emitter {
           }
           // eslint-disable-next-line max-len
           debug(`MediaServer#connectCaller - createUAC (srtp scenario) produced dialog for ${uuid}: ${JSON.stringify(dlg)}`) ;
-
+          if(opts.modifyMrfSdpResponse instanceof Function) {
+            debug(`MediaServer#connectCaller - modifying (srtp scenario) sdp returned using opts.modifyMrfSdpResponse on ${uuid}`) ;
+            dlg.remote.sdp = opts.modifyMrfSdpResponse(dlg.remote.sdp)
+          }
           /* update pending connection state now that freeswitch has answered */
           const obj = this.pendingConnections.get(uuid);
           obj.dialog = dlg;


### PR DESCRIPTION
I needed to add some SDP fields to improve WebRTC video quality on Chrome and Safari. This required that I intercept the SDP coming back from FreeSwitch before its passed back to the WebRTC client.

In my case I'm adding these fields on all `a=fmtp` lines:
```
x-google-max-bitrate=6000;x-google-min-bitrate=2000;x-google-start-bitrate=2000
```

I enabled this functionality by adding an optional function that can be passed to `mediaserver.connectCaller` called `modifyMrfSdpResponse`.

Here is an example of it being used:
```
        var {endpoint, dialog} = await thisMediaServer.connectCaller(this.req, this.res, {modifyMrfSdpResponse: function(sdp) {
          console.log("FS SDP==========================================")
          var remoteArr = sdp.split('\r\n');
          remoteArr.forEach((str, i) => {
            if (/^a=fmtp:\d*/.test(str)) {
              remoteArr[i] = str + ';x-google-max-bitrate=6000;x-google-min-bitrate=2000;x-google-start-bitrate=4000';
            } else if (/^a=mid:(1|video)/.test(str)) {
              remoteArr[i] += '\r\nb=AS:6000';
            }
          });
          var newRemote = remoteArr.join('\r\n');
          //console.log(newRemote)
          return newRemote;
        }})  
```

With this implemented I have improved the quality of my video calls by many times. These SDP parameters are respected by both Chrome and Safar.