### PR TITLE
User-Agent header is overwritten

### DIFF
--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -382,10 +382,10 @@ class MediaServer extends Emitter {
 
         /* send invite to freeswitch */
         this.srf.createUAC(uri, {
-          headers: {
+          headers: Object.assign(opts.headers || {}, {
             'User-Agent': `drachtio-fsmrf:${uuid}`,
             'X-esl-outbound': `${this.advertisedAddress}:${this.advertisedPort}`
-          },
+          }),
           localSdp: req.body
         }, {}, (err, dlg) => {
           if (err) {

--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -382,10 +382,11 @@ class MediaServer extends Emitter {
 
         /* send invite to freeswitch */
         this.srf.createUAC(uri, {
-          headers: Object.assign(opts.headers || {}, {
+          headers: {
+            ...opts.headers,
             'User-Agent': `drachtio-fsmrf:${uuid}`,
             'X-esl-outbound': `${this.advertisedAddress}:${this.advertisedPort}`
-          }),
+          },
           localSdp: req.body
         }, {}, (err, dlg) => {
           if (err) {

--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -299,7 +299,8 @@ class MediaServer extends Emitter {
       this.pendingConnections.set(uuid, {});
       try {
         const dlg = await this.srf.createUAC(uri, {
-          headers: Object.assign(opts.headers, {
+          headers: {
+            ...opts.headers,
             'User-Agent': `drachtio-fsmrf:${uuid}`,
             'X-esl-outbound': `${this.advertisedAddress}:${this.advertisedPort}`
           }),

--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -303,7 +303,7 @@ class MediaServer extends Emitter {
             ...opts.headers,
             'User-Agent': `drachtio-fsmrf:${uuid}`,
             'X-esl-outbound': `${this.advertisedAddress}:${this.advertisedPort}`
-          }),
+          },
           localSdp: opts.remoteSdp
         });
         debug(`MediaServer#createEndpoint - createUAC produced dialog for ${uuid}`) ;


### PR DESCRIPTION
In case drachtio app is UAS and responds 200 OK to remote sip server, my app sets own User-Agent header but is always overwritten to "drachtio-fsmrf:{uuid}" which is used only with freeswitch side.
Besides, X-esl-outbound header is also responded to remote sip server.