### PR TITLE
fix createEndpoint and connectCaller

### DIFF
--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -299,10 +299,11 @@ class MediaServer extends Emitter {
       this.pendingConnections.set(uuid, {});
       try {
         const dlg = await this.srf.createUAC(uri, {
-          headers: Object.assign(opts.headers, {
+          headers: {
+            ...opts.headers,
             'User-Agent': `drachtio-fsmrf:${uuid}`,
             'X-esl-outbound': `${this.advertisedAddress}:${this.advertisedPort}`
-          }),
+          },
           localSdp: opts.remoteSdp
         });
         debug(`MediaServer#createEndpoint - createUAC produced dialog for ${uuid}`) ;
@@ -438,6 +439,7 @@ class MediaServer extends Emitter {
         const timeoutFn = (dialog, uuid) => {
           delete this.pendingConnections.delete(uuid);
           dialog.destroy();
+          pair.dialog && pair.dialog.destroy(); // UA dialog destroy
           debug(`MediaServer#createEndpoint - (srtp scenario) connection timeout for ${uuid}`);
           callback(new Error('Connection timeout')) ;
         };


### PR DESCRIPTION
1. Freeswitch headers for internal esl connection are unnecessarily included and sent to remote SIP server inside 200 OK.
2. UA dialog also should be destroyed in timeoutFn callback of connectCaller function because app cannot get UA dialog object when freeswitch connection timeout error is thrown.