### PR TITLE
Fix unhandled Promise rejection

### DIFF
--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -359,16 +359,24 @@ class MediaServer extends Emitter {
 
       // scenario 1: plain old RTP
       if (!requiresDtlsHandshake(req.body)) {
-        const endpoint = await this.createEndpoint({
+        this.createEndpoint({
           ...opts,
           remoteSdp: opts.remoteSdp || req.body,
           codecs: opts.codecs
+        }, (err, endpoint) => {
+          if(err) {
+            return callback(err);
+          }
+          this.srf.createUAS(req, res, {
+            localSdp: endpoint.local.sdp,
+            headers: opts.headers
+          }, (err, dialog) => {
+            if(err) {
+              return callback(err);
+            }
+            callback(null, {endpoint, dialog}) ;
+          });
         });
-        const dialog = await this.srf.createUAS(req, res, {
-          localSdp: endpoint.local.sdp,
-          headers: opts.headers
-        });
-        callback(null, {endpoint, dialog}) ;
       }
       else {
         // scenario 2: SRTP is being used and therefore creating an endpoint

--- a/lib/mediaserver.js
+++ b/lib/mediaserver.js
@@ -359,24 +359,20 @@ class MediaServer extends Emitter {
 
       // scenario 1: plain old RTP
       if (!requiresDtlsHandshake(req.body)) {
-        this.createEndpoint({
-          ...opts,
-          remoteSdp: opts.remoteSdp || req.body,
-          codecs: opts.codecs
-        }, (err, endpoint) => {
-          if(err) {
-            return callback(err);
-          }
-          this.srf.createUAS(req, res, {
+        try {
+          const endpoint = await this.createEndpoint({
+            ...opts,
+            remoteSdp: opts.remoteSdp || req.body,
+            codecs: opts.codecs
+          });
+          const dialog = await this.srf.createUAS(req, res, {
             localSdp: endpoint.local.sdp,
             headers: opts.headers
-          }, (err, dialog) => {
-            if(err) {
-              return callback(err);
-            }
-            callback(null, {endpoint, dialog}) ;
           });
-        });
+          callback(null, {endpoint, dialog}) ;
+        } catch (err) {
+          callback(err);
+        }
       }
       else {
         // scenario 2: SRTP is being used and therefore creating an endpoint


### PR DESCRIPTION
In case srf.createUAC function is failed inside this.createEndpoint function, "You have triggered an unhandledRejection, you may have forgotten to catch a Promise rejection" error is raised and no callback is called to fsmrf app side.