### PR TITLE
Fix forkAudioResume to send 'resume'

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -1168,7 +1168,7 @@ class Endpoint extends Emitter {
    * a reference to the Endpoint object
    */
   forkAudioResume(bugname, callback) {
-    const args = [this.uuid, 'pause'];
+    const args = [this.uuid, 'resume'];
     if (arguments.length === 1) {
       // If the function is called with 1 argument, could be bugname or callback.
       if (typeof bugname === 'function') {


### PR DESCRIPTION
I noticed in jambonz-feature-server that updating the call with `"listen_status": "pause"` was working but when sending `"listen_status": "resume"` nothing happened. 

Dug into the problem and it looks like there was just a copy-paste error in this commit:
https://github.com/drachtio/drachtio-fsmrf/commit/0268a19521abb6371430cab818c663f7b56f3704#diff-91c5a0489e5aceb96a7e44bb0d4cfd4b8eee8cb0155b5d101e27c6a45d40ddb6R1108-L1035

Signed-off-by: Matt Hertogs <mhertogs@hiya.com>