### PR TITLE
add resetEslCustomEvent to recover the endpoint after conference

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -195,6 +195,15 @@ class Endpoint extends Emitter {
    * @returns {Promise} a promise is returned if no callback is supplied
    */
   export(param, value, callback) { return setOrExport('export', this, param, value, callback); }
+  /**
+   * When the endpoint is used for conference, the esl::event::CUSTOM::<uuid> will be overide to conference
+   * listener. This API allow top application reset the esl::event::CUSTOM event to recover the endpoint functionality
+   */
+
+  resetEslCustomEvent() {
+    this.conn.removeAllListeners('esl::event::CUSTOM::*');
+    this.conn.on(`esl::event::CUSTOM::${this.uuid}`, this._onCustomEvent.bind(this));
+  }
 
   /**
    * subscribe for custom events


### PR DESCRIPTION
When the endpoint is used for conference, the esl CUSTOM event will be override to conference listener, this PR provide new API to reset the listener for the endpoint.

https://github.com/drachtio/drachtio-fsmrf/blob/main/lib/endpoint.js#L584