### PR TITLE
attach reason when endpoint is hanguped

### DIFF
--- a/lib/endpoint.js
+++ b/lib/endpoint.js
@@ -1670,7 +1670,8 @@ class Endpoint extends Emitter {
     if ('HANGUP' === channelCallState && State.CONNECTED === this.state) {
       debug(`Endpoint#_onChannelCallState ${this.uuid}: got BYE from Freeswitch end of call`);
       this.state = State.DISCONNECTED;
-      this.emit('destroy');
+      const reason = evt.getHeader('Hangup-Cause')  ;
+      this.emit('destroy', {reason});
     }
 
     this.emit('channelCallState', {state: channelCallState});


### PR DESCRIPTION
To detect if the endpoint is hangup by normal clean up or MEDIA_TIMEOUT